### PR TITLE
Add Naturally.sort_filenames for filename-friendly sorting (fixes #24)

### DIFF
--- a/lib/naturally.rb
+++ b/lib/naturally.rb
@@ -49,6 +49,16 @@ module Naturally
     tokens.map { |t| Segment.new(t) }
   end
 
+  # Natural sort for filenames, treating underscores and dots as separators.
+  # Dots are given higher priority by inserting a '0' segment, as in user workaround.
+  # See Issue #24.
+  def self.sort_filenames(array)
+    array.sort_by do |filename|
+      # Replace '.' with '.0.' to give dot higher priority, then split on dot or underscore
+      filename.to_s.gsub('.', '.0.').split(/[\._]/).map { |t| Segment.new(t) }
+    end
+  end
+
   private
   # Sort an array of objects "naturally", yielding each object
   # to the block to obtain the sort key.

--- a/spec/naturally_spec.rb
+++ b/spec/naturally_spec.rb
@@ -208,4 +208,16 @@ describe Naturally do
       ]
     end
   end
+
+  describe '#sort_filenames' do
+    it 'sorts filenames with underscores and dots as separators' do
+      expect(Naturally.sort_filenames(['abc_2.tif', 'abc_1_a.tif'])).to eq(["abc_1_a.tif", "abc_2.tif"])
+      expect(Naturally.sort_filenames(['abc_1.zzz', 'abc_1_xyz.abc'])).to eq(["abc_1.zzz", "abc_1_xyz.abc"])
+      expect(Naturally.sort_filenames(['abc_2a.tif', 'abc_1_a.tif'])).to eq(["abc_1_a.tif", "abc_2a.tif"])
+      expect(Naturally.sort_filenames(['abc.2.tif', 'abc.1_a.tif'])).to eq(["abc.1_a.tif", "abc.2.tif"])
+      expect(Naturally.sort_filenames(['abc_2.tif', 'abc_1.tif'])).to eq(["abc_1.tif", "abc_2.tif"])
+      expect(Naturally.sort_filenames(['abc_2.tif', 'abc_1_a.tif'])).to eq(["abc_1_a.tif", "abc_2.tif"])
+      expect(Naturally.sort_filenames(['abc_2.abc', 'abc_1_xyz.abc'])).to eq(["abc_1_xyz.abc", "abc_2.abc"])
+    end
+  end
 end


### PR DESCRIPTION
- Adds a new method Naturally.sort_filenames that treats underscores and dots as separators, with dots given higher priority, for natural sorting of filenames.
- Includes comprehensive tests for common filename cases.
- Fixes and references Issue #24.