### PR TITLE
Docs: Add changelog, README, and version bump for #sort_filenames (v2.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.3.0] - 2025-06-11
+
+### Added
+- New `#sort_filenames` method for sorting filenames with underscores and dots as separators
+- Dots are given higher priority than underscores in filename sorting
+- Comprehensive test coverage for filename sorting scenarios
+
+### Changed
+- Updated README with documentation and examples for the new `#sort_filenames` method
+
+## [2.2.2] - Previous Release
+
+### Notes
+- Previous stable release
+- Included support for natural sorting with legal numbering, course codes, and Unicode
+- Maintained compatibility with Ruby 2.0+
+
+## Historical Releases
+
+For releases prior to 2.2.2, please refer to the git commit history.
+
+---
+
+**Note**: This changelog was introduced in version 2.3.0. Future releases will document all changes here.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,39 @@ expect(sorted.map(&:name)).to eq [
 [More examples are in the specs](https://github.com/public-law/naturally/blob/master/spec/naturally_spec.rb).
 
 
+## `#sort_filenames`
+
+Sorts filenames naturally, treating underscores and dots as separators. Useful for sorting files like images or documents that use numbers, underscores, and dots in their names.
+
+```ruby
+files = [
+  'abc_2.tif',
+  'abc_1_a.tif',
+  'abc_1.zzz',
+  'abc_1_xyz.abc',
+  'abc_2a.tif',
+  'abc.2.tif',
+  'abc.1_a.tif',
+  'abc_2.abc',
+  'abc_1_xyz.abc'
+]
+Naturally.sort_filenames(files)
+# => [
+#   "abc.1_a.tif",
+#   "abc.2.tif",
+#   "abc_1.zzz",
+#   "abc_1_a.tif",
+#   "abc_1_xyz.abc",
+#   "abc_1_xyz.abc",
+#   "abc_2.abc",
+#   "abc_2.tif",
+#   "abc_2a.tif"
+# ]
+```
+
+This method gives higher priority to dots than underscores, so files like `abc.1_a.tif` will come before `abc.2.tif`.
+
+
 ## Implementation Notes
 
 The algorithm capitalizes on Ruby's array comparison behavior:

--- a/lib/naturally/version.rb
+++ b/lib/naturally/version.rb
@@ -1,4 +1,4 @@
 module Naturally
   # Gem version
-  VERSION = '2.2.2'
+  VERSION = '2.3.0'
 end


### PR DESCRIPTION
This PR documents the new #sort_filenames method and prepares for the v2.3.0 release.

- Adds a README section for  with usage and examples
- Bumps the version to 2.3.0
- Adds a CHANGELOG.md following Keep a Changelog

Closes #24

/cc @public-law